### PR TITLE
total re-work of time handling

### DIFF
--- a/alarm.xcodeproj/project.pbxproj
+++ b/alarm.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		273E0DD31AAD6591005D73E3 /* TimePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273E0DD21AAD6591005D73E3 /* TimePresenter.swift */; };
 		274DA5681AB4E08900891EBF /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274DA5661AB4E08900891EBF /* HomeViewController.swift */; };
 		274DA5691AB4E08900891EBF /* HomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 274DA5671AB4E08900891EBF /* HomeViewController.xib */; };
+		2751201C1AB5AB9A007F1219 /* RawTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2751201B1AB5AB9A007F1219 /* RawTime.swift */; };
 		27A71A991AB51551003CABC4 /* SunriseHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A71A981AB51551003CABC4 /* SunriseHelper.swift */; };
 		27C827981AB4FCA20021CCD3 /* BlurPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C827971AB4FCA20021CCD3 /* BlurPresenter.swift */; };
 		27FE93831AB00FE600059E18 /* AlarmEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FE93821AB00FE600059E18 /* AlarmEntity.swift */; };
@@ -60,6 +61,7 @@
 		273E0DD21AAD6591005D73E3 /* TimePresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimePresenter.swift; sourceTree = "<group>"; };
 		274DA5661AB4E08900891EBF /* HomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		274DA5671AB4E08900891EBF /* HomeViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HomeViewController.xib; sourceTree = "<group>"; };
+		2751201B1AB5AB9A007F1219 /* RawTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawTime.swift; sourceTree = "<group>"; };
 		27A71A981AB51551003CABC4 /* SunriseHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SunriseHelper.swift; sourceTree = "<group>"; };
 		27C827971AB4FCA20021CCD3 /* BlurPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlurPresenter.swift; sourceTree = "<group>"; };
 		27FE93821AB00FE600059E18 /* AlarmEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmEntity.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 			children = (
 				27C827971AB4FCA20021CCD3 /* BlurPresenter.swift */,
 				273E0DD21AAD6591005D73E3 /* TimePresenter.swift */,
+				2751201B1AB5AB9A007F1219 /* RawTime.swift */,
 				27A71A981AB51551003CABC4 /* SunriseHelper.swift */,
 			);
 			name = Lib;
@@ -351,6 +354,7 @@
 				274DA5681AB4E08900891EBF /* HomeViewController.swift in Sources */,
 				25E7C68E1AA8284100431A81 /* AppDelegate.swift in Sources */,
 				25E7C6911AA8284100431A81 /* alarm.xcdatamodeld in Sources */,
+				2751201C1AB5AB9A007F1219 /* RawTime.swift in Sources */,
 				273E0DD31AAD6591005D73E3 /* TimePresenter.swift in Sources */,
 				27FE93831AB00FE600059E18 /* AlarmEntity.swift in Sources */,
 			);

--- a/alarm/AlarmEntity.swift
+++ b/alarm/AlarmEntity.swift
@@ -63,23 +63,40 @@ class AlarmEntity: NSManagedObject {
     }
   }
 
-  func applyTimePresenter(time: TimePresenter) {
-    self.alarmTypeEnum = .Time
-    self.hour = Int16(time.hour24)
-    self.minute = Int16(time.minute)
+  // Given a TimePresenter, apply it to this AlarmEntity
+  // This supports both time-based and sunrise/sunset TimePresenters
+  func applyTimePresenter(timePresenter: TimePresenter) {
+    // Keep whatever type it was
+    self.alarmTypeEnum = timePresenter.type
+
+    // If the presenter is a static time, copy it over. Otherwise,
+    // just use the type and allow this instance to figure out it's
+    // own sunrise/sunset times.
+    switch timePresenter.type {
+    case .Time:
+      self.hour = Int16(timePresenter.time!.hour24)
+      self.minute = Int16(timePresenter.time!.minute)
+    default:
+      // If it's for sunrise/sunset, just leave invalid sentinel values.
+      self.hour = -1
+      self.minute = -1
+    }
+
+    // Persist the change to the DB
     self.persistSelf()
   }
 
+  // Get a displayable form of the `dayOfWeek` variable.
   func dayOfWeekForDisplay() -> String {
     return dayOfWeek.capitalizedString
   }
 
   // Generate a displayable version of this time
-  func timeForTableDisplay() -> String {
+  func stringForTableDisplay() -> String {
     switch alarmTypeEnum {
     case .Time:
       let time = TimePresenter(alarmEntity: self)
-      return time.tableDisplayStr()
+      return time.stringForTableDisplay()
     case .Sunrise:
       return "sunrise"
     case .Sunset:
@@ -90,15 +107,10 @@ class AlarmEntity: NSManagedObject {
     }
   }
 
-  // Update the persistance layer for this alarm
-  func updateTime(type: AlarmType, hour: Int16?, minute: Int16?) {
-    self.alarmTypeEnum = type
-    self.hour = hour ?? 0
-    self.minute = minute ?? 0
 
-    self.persistSelf()
-  }
+  /* Private */
 
+  // TODO: Implement me
   private func persistSelf() {
   }
 }

--- a/alarm/BlurPresenter.swift
+++ b/alarm/BlurPresenter.swift
@@ -44,7 +44,6 @@ class BlurPresenter {
   }
 
   func showBlur() {
-    NSLog("Showing blur")
     resetBounds()
     blurEffectView.hidden = false
   }
@@ -53,6 +52,11 @@ class BlurPresenter {
     blurEffectView.hidden = true
   }
 
+
+  /* Private */
+
+  // When we show the view, frames could have changed so we want
+  // to reset them easily.
   private func resetBounds() {
     blurEffectView.frame = self.parentView.bounds
     vibrancyEffectView.frame = self.parentView.bounds

--- a/alarm/HomeViewController.swift
+++ b/alarm/HomeViewController.swift
@@ -20,6 +20,11 @@ class HomeViewController: UIViewController, TimePickerDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    // Set up a default TimePresenter
+    // TODO: Make this real, based upon active alarms
+    currentTime = TimePresenter(hour24: 7, minute: 30)
+    updateDisplayTime()
+
     // Do any additional setup after loading the view.
     blurPresenter = BlurPresenter(parent: self.view)
   }
@@ -43,6 +48,9 @@ class HomeViewController: UIViewController, TimePickerDelegate {
     alarmViewController.modalPresentationStyle = UIModalPresentationStyle.OverCurrentContext
     alarmViewController.modalTransitionStyle = UIModalTransitionStyle.CrossDissolve
 
+    // Let the picker know what it should have selected
+    alarmViewController.startingTimePresenter = currentTime
+
     // Present the new controller
     presentViewController(alarmViewController, animated: true, completion: nil)
   }
@@ -52,6 +60,9 @@ class HomeViewController: UIViewController, TimePickerDelegate {
     currentTime = time
     updateDisplayTime()
   }
+
+
+  /* Private */
 
   // Update the displayed time
   private func updateDisplayTime() {

--- a/alarm/RawTime.swift
+++ b/alarm/RawTime.swift
@@ -1,0 +1,60 @@
+//
+//  RawTime.swift
+//  alarm
+//
+//  Created by Michael Lewis on 3/15/15.
+//  Copyright (c) 2015 Kevin Farst. All rights reserved.
+//
+
+import Foundation
+
+// RawTime is a helper class that contains an hour/minute pair
+// It provides some _very_ basic logic for converting between
+// 24-hour and 12-hour time. It stores in 24-hour time.
+struct RawTime: Comparable, Hashable {
+  enum AmPm {
+    case AM
+    case PM
+  }
+
+  // Only `hour24` and `minute` are required
+  var hour24: Int
+  var minute: Int
+
+  // All other variables are derived
+  var hour12: Int {
+    get {
+      if hour24 < 12 {
+        return hour24
+      } else {
+        return hour24 - 12
+      }
+    }
+  }
+
+  var amOrPm: AmPm {
+    if hour24 < 12 {
+      return .AM
+    } else {
+      return .PM
+    }
+  }
+
+  var hashValue: Int {
+    get {
+      return hour24.hashValue ^ minute.hashValue
+    }
+  }
+}
+
+// Comparison operators for RawTime
+func <(left: RawTime, right: RawTime) -> Bool {
+  return (
+    left.hour24 < right.hour24 ||
+    (left.hour24 == right.hour24 && left.minute < right.minute)
+  )
+}
+
+func ==(left: RawTime, right: RawTime) -> Bool {
+  return left.hour24 == right.hour24 && left.minute == right.minute
+}

--- a/alarm/ScheduleTableViewCell.swift
+++ b/alarm/ScheduleTableViewCell.swift
@@ -21,7 +21,7 @@ class ScheduleTableViewCell: UITableViewCell {
   var alarmEntity: AlarmEntity! {
     didSet {
       dayLabel.text = alarmEntity.dayOfWeekForDisplay()
-      timeButton.setTitle(alarmEntity.timeForTableDisplay(), forState: UIControlState.Normal)
+      timeButton.setTitle(alarmEntity.stringForTableDisplay(), forState: UIControlState.Normal)
       //activeSwitch.on = alarmEntity.enabled
     }
   }

--- a/alarm/ScheduleViewController.swift
+++ b/alarm/ScheduleViewController.swift
@@ -63,7 +63,7 @@ class ScheduleViewController: UIViewController, UITableViewDataSource, UITableVi
   }
   
   // Delegate callback from the time picker
-  func timeSelected(time: TimeElement) {
+  func timeSelected(time: TimePresenter) {
     updateDisplayTime()
   }
   
@@ -82,14 +82,21 @@ class ScheduleViewController: UIViewController, UITableViewDataSource, UITableVi
       alarmViewController.delegate = self
       alarmViewController.modalPresentationStyle = UIModalPresentationStyle.OverCurrentContext
       alarmViewController.modalTransitionStyle = UIModalTransitionStyle.CrossDissolve
-      
+
+      // Let the picker know what it should have selected by default
+      alarmViewController.startingTimePresenter = currentTime
+
       // Present the new controller
       presentViewController(alarmViewController, animated: true, completion: nil)
     }
   }
+
+
+  /* Private */
   
   // Update the displayed time
   private func updateDisplayTime() {
+    // TODO: Implement me
   }
   
   // TODO: We need to replace this with live Core Data entities from the database

--- a/alarm/SunriseHelper.swift
+++ b/alarm/SunriseHelper.swift
@@ -13,59 +13,72 @@ private let _SunriseHelperSharedInstance = SunriseHelper()
 
 class SunriseHelper {
 
-  let calculator: EDSunriseSet
   let calendar: NSCalendar
-  var lastCalc: NSDate?
+  let calculator: EDSunriseSet
+  // Store the last time we ran the sunrise/sunset calculations.
+  // They need to be re-run every time we roll over a day.
+  var lastCalculation: NSDate?
 
   init() {
+    calendar = NSCalendar.currentCalendar()
     calculator = EDSunriseSet(
       timezone: NSTimeZone.localTimeZone(),
       latitude: 37.7833,
       longitude: -122.4167
     )
-    calendar = NSCalendar.currentCalendar()
   }
 
-  // Return a TimePresenter set to sunrise
-  func sunrise() -> TimePresenter {
-    let components = getLocalHourMinuteComponents(calculator.sunrise)
-    return TimePresenter(
-      hour24: components.hour,
-      minute: components.hour,
-      type: .Sunrise
-    )
+  // Create and hold onto a singleton instance of this class
+  // because calculations and heavy and should be cached
+  // for performance reasons.
+  class var singleton: SunriseHelper {
+    return _SunriseHelperSharedInstance
   }
 
-  // Return a TimePresenter set to sunset
-  func sunset() -> TimePresenter {
-    let components = getLocalHourMinuteComponents(calculator.sunset)
-    return TimePresenter(
-      hour24: components.hour,
-      minute: components.hour,
-      type: .Sunset
-    )
+  // Return a RawTime struct set to sunrise
+  // This is clearly only valid for the day it was generated
+  func sunrise() -> RawTime {
+    self.updateIfNeeded()
+    return getRawTimeForLocalNSDate(calculator.sunrise)
   }
 
+  // Return a RawTime struct set to sunset
+  // This is clearly only valid for the day it was generated
+  func sunset() -> RawTime {
+    self.updateIfNeeded()
+    return getRawTimeForLocalNSDate(calculator.sunset)
+  }
+
+
+  /* Private */
 
   // If we haven't recalculated sunrise and sunset for today
+  // then recalculate here and timestamp it.
   private func updateIfNeeded() {
-    if let last = lastCalc {
-      if calendar.isDateInToday(last) {
+    if let lastCalc = lastCalculation {
+      if calendar.isDateInToday(lastCalc) {
         // The `lastCalc` NSDate is within today. Skip calculations.
         return
       }
     }
 
     // We got here if we need to recalculate
-    lastCalc = NSDate()
-    calculator.calculateSunriseSunset(lastCalc)
+    NSLog("Recalculating sunrise and sunset")
+    self.lastCalculation = NSDate()
+    calculator.calculateSunriseSunset(self.lastCalculation)
   }
 
+  // Get the NSDateComponents for the current calendar/timezone
+  // given an input NSDate.
   private func getLocalHourMinuteComponents(date: NSDate) -> NSDateComponents {
     return calendar.components(NSCalendarUnit.CalendarUnitHour | NSCalendarUnit.CalendarUnitMinute, fromDate: date)
   }
 
-  class var singleton: SunriseHelper {
-    return _SunriseHelperSharedInstance
+  private func getRawTimeForLocalNSDate(date: NSDate) -> RawTime {
+    let components = getLocalHourMinuteComponents(date)
+    return RawTime(
+      hour24: components.hour,
+      minute: components.minute
+    )
   }
 }

--- a/alarm/TimePresenter.swift
+++ b/alarm/TimePresenter.swift
@@ -8,81 +8,91 @@
 
 import Foundation
 
-class TimePresenter {
-  let hour24: Int
-  let hour12: Int
-  let minute: Int
-  let amOrPm: String // either "am" or "pm"
+class TimePresenter: Comparable {
   // Support time-based, or sunrise/sunset based
   let type: AlarmEntity.AlarmType
+  let time: RawTime?
 
-
-  // Default to the time type but allow overriding
-  init(hour24: Int, minute: Int, type: AlarmEntity.AlarmType = .Time) {
-    self.hour24 = hour24
-    self.minute = minute
+  // Time type is required, and a raw time is optional
+  init(type: AlarmEntity.AlarmType, time: RawTime? = nil) {
     self.type = type
+    self.time = time
 
-    // Determine AM vs PM and adjust the hour to a 12 hour clock
-    if hour24 < 12 {
-      self.hour12 = hour24
-      self.amOrPm = "am"
-    } else {
-      self.hour12 = hour24 - 12
-      self.amOrPm = "pm"
-    }
-
-    if self.hour24 == 0 {
-      self.hour24 = 12
+    // If we're dealing with an AlarmType of .Time, ensure
+    // that we have a valid `time`.
+    if type == .Time {
+      assert(time != nil)
     }
   }
 
+  // Allow creation by raw hours/minutes
+  convenience init(hour24: Int, minute: Int) {
+    self.init(type: .Time, time: RawTime(hour24: hour24, minute: minute))
+  }
+
+  // Create a TimePresenter, using an AlarmEntity as the base
   convenience init(alarmEntity: AlarmEntity) {
-    self.init(hour24: Int(alarmEntity.hour), minute: Int(alarmEntity.minute))
-  }
-
-  convenience init(type: AlarmEntity.AlarmType) {
-    switch type {
+    switch alarmEntity.alarmTypeEnum {
     case .Time:
-      NSLog("This is being improperly initialized. The alarm type initializer is not for .Time")
-      self.init(hour24: 0, minute: 0)
-    case .Sunrise:
-      self.init(hour24: 0, minute: 0)
-    case .Sunset:
-      self.init(hour24: 0, minute: 0)
+      self.init(
+        hour24: Int(alarmEntity.hour),
+        minute: Int(alarmEntity.minute)
+      )
+    default:
+      self.init(type: alarmEntity.alarmTypeEnum)
     }
   }
 
+  // This presenter supports static times as well as sun-based times
+  // This function will return a raw time representing what the
+  // true time is, no matter how this presenter was constructed.
+  func calculatedTime() -> RawTime {
+    switch self.type {
+    case .Time:
+      return time!
+    case .Sunrise:
+      return SunriseHelper.singleton.sunrise()
+    case .Sunset:
+      return SunriseHelper.singleton.sunset()
+    }
+  }
 
   // Don't include the am/pm portion in the main wheel
-  func wheelDisplayStr() -> String {
+  func stringForWheelDisplay() -> String {
+    // Precalculate the time for speed
+    let time = calculatedTime()
+
     switch self.type {
     case .Time:
       // Special formatting for special times
-      if hour24 == 0 && minute == 0 {
+      if time.hour24 == 0 && time.minute == 0 {
         return "midnight"
-      } else if hour24 == 12 && minute == 0 {
+      } else if time.hour24 == 12 && time.minute == 0 {
         return "noon"
       } else {
-        return String(format: "%02d : %02d", self.hour12, self.minute)
+        return String(format: "%02d : %02d", time.hour12, time.minute)
       }
     case .Sunrise:
-      return "sunrise"
+      return String(format: "sunrise (%02d:%02d)", time.hour12, time.minute)
     case .Sunset:
-      return "sunset"
+      return String(format: "sunset (%02d:%02d)", time.hour12, time.minute)
     }
   }
 
-  func tableDisplayStr() -> String {
+  // The table display view doesn't need times for sunrise/sunset
+  func stringForTableDisplay() -> String {
+    // Precalculate the time for speed
+    let time = calculatedTime()
+
     switch self.type {
     case .Time:
       // Special formatting for special times
-      if hour24 == 0 && minute == 0 {
+      if time.hour24 == 0 && time.minute == 0 {
         return "midnight"
-      } else if hour24 == 12 && minute == 0 {
+      } else if time.hour24 == 12 && time.minute == 0 {
         return "noon"
       } else {
-        return String(format: "%02d:%02d %@", self.hour12, self.minute, self.amOrPm)
+        return String(format: "%02d:%02d %@", time.hour12, time.minute, self.amPmToString(time.amOrPm))
       }
     case .Sunrise:
       return "sunrise"
@@ -92,13 +102,56 @@ class TimePresenter {
   }
 
   // Generate all of the time elements that we will allow
+  // This includes sunset and sunrise.
   class func generateAllElements() -> Array<TimePresenter> {
-    return (0...23).map {
+    // Start by generating the static times
+    var times = (0...23).map {
       hour in
       [0, 15, 30, 45].map {
         minute in
         TimePresenter(hour24: hour, minute: minute)
       }
     }.reduce([], +)
+
+    // Add in sunrise and sunset
+    times.append(TimePresenter(type: AlarmEntity.AlarmType.Sunrise))
+    times.append(TimePresenter(type: AlarmEntity.AlarmType.Sunset))
+
+    // Sort the entire array, based upon calculated time
+    return times.sorted { $0 < $1 }
+  }
+
+
+  /* Private */
+
+  private func amPmToString(amPm: RawTime.AmPm) -> String {
+    switch amPm {
+    case .AM:
+      return "am"
+    case .PM:
+      return "pm"
+    }
+  }
+}
+
+// Comparison operators for TimePresenter
+func <(left: TimePresenter, right: TimePresenter) -> Bool {
+  return left.calculatedTime() < right.calculatedTime()
+}
+
+func ==(left: TimePresenter, right: TimePresenter) -> Bool {
+  // They have to share the same type to be equal
+  if left.type == right.type {
+    switch left.type {
+    case .Time:
+      // If it's static time, make sure it's the same
+      return left.time == right.time
+    default:
+      // If it's sunrise/sunset, type alone is enough
+      return true
+    }
+  } else {
+    // If type is different, they're inequal
+    return false
   }
 }


### PR DESCRIPTION
This should make time handling much easier to deal with.

Hours and minutes are wrapped in a `RawTime` struct that is used by `TimePresenter`s. The initialization methods are much simpler for them as well now.

Sunrise and sunset work at all layers, including in `AlarmEntity`. They are also included in the picker.

Added the ability to select the active row for the time picker using a `TimePresenter`.

@kfarst 
