### PR TITLE
Alarm helper

### DIFF
--- a/alarm.xcodeproj/project.pbxproj
+++ b/alarm.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		275120201AB60D4C007F1219 /* LocationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2751201F1AB60D4C007F1219 /* LocationHelper.swift */; };
 		275120221AB64932007F1219 /* SoundMonitorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275120211AB64932007F1219 /* SoundMonitorHelper.swift */; };
 		275120261AB8E4F6007F1219 /* AlarmHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275120251AB8E4F6007F1219 /* AlarmHelper.swift */; };
+		277FFD0A1ABA10890003BE2A /* AlarmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277FFD091ABA10890003BE2A /* AlarmManager.swift */; };
 		27A71A991AB51551003CABC4 /* SunriseHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A71A981AB51551003CABC4 /* SunriseHelper.swift */; };
 		27C827981AB4FCA20021CCD3 /* BlurViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */; };
 		27FE93831AB00FE600059E18 /* AlarmEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FE93821AB00FE600059E18 /* AlarmEntity.swift */; };
@@ -74,6 +75,7 @@
 		2751201F1AB60D4C007F1219 /* LocationHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationHelper.swift; sourceTree = "<group>"; };
 		275120211AB64932007F1219 /* SoundMonitorHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SoundMonitorHelper.swift; sourceTree = "<group>"; };
 		275120251AB8E4F6007F1219 /* AlarmHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmHelper.swift; sourceTree = "<group>"; };
+		277FFD091ABA10890003BE2A /* AlarmManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmManager.swift; sourceTree = "<group>"; };
 		27A71A981AB51551003CABC4 /* SunriseHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SunriseHelper.swift; sourceTree = "<group>"; };
 		27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlurViewPresenter.swift; sourceTree = "<group>"; };
 		27FE93821AB00FE600059E18 /* AlarmEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmEntity.swift; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 			isa = PBXGroup;
 			children = (
 				275120251AB8E4F6007F1219 /* AlarmHelper.swift */,
+				277FFD091ABA10890003BE2A /* AlarmManager.swift */,
 				2751201D1AB5C738007F1219 /* AlarmPickerPresenter.swift */,
 				27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */,
 				2751201F1AB60D4C007F1219 /* LocationHelper.swift */,
@@ -377,6 +380,7 @@
 				2544787B1AB63411002FA3CB /* SettingsModalViewController.swift in Sources */,
 				2751201E1AB5C738007F1219 /* AlarmPickerPresenter.swift in Sources */,
 				273C35A41AAFFEDC00743B33 /* ScheduleTableViewCell.swift in Sources */,
+				277FFD0A1ABA10890003BE2A /* AlarmManager.swift in Sources */,
 				275120221AB64932007F1219 /* SoundMonitorHelper.swift in Sources */,
 				274DA5681AB4E08900891EBF /* HomeViewController.swift in Sources */,
 				275120261AB8E4F6007F1219 /* AlarmHelper.swift in Sources */,

--- a/alarm.xcodeproj/project.pbxproj
+++ b/alarm.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		2751201E1AB5C738007F1219 /* AlarmPickerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2751201D1AB5C738007F1219 /* AlarmPickerPresenter.swift */; };
 		275120201AB60D4C007F1219 /* LocationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2751201F1AB60D4C007F1219 /* LocationHelper.swift */; };
 		275120221AB64932007F1219 /* SoundMonitorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275120211AB64932007F1219 /* SoundMonitorHelper.swift */; };
+		275120261AB8E4F6007F1219 /* AlarmHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275120251AB8E4F6007F1219 /* AlarmHelper.swift */; };
 		27A71A991AB51551003CABC4 /* SunriseHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A71A981AB51551003CABC4 /* SunriseHelper.swift */; };
 		27C827981AB4FCA20021CCD3 /* BlurViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */; };
 		27FE93831AB00FE600059E18 /* AlarmEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FE93821AB00FE600059E18 /* AlarmEntity.swift */; };
@@ -72,6 +73,7 @@
 		2751201D1AB5C738007F1219 /* AlarmPickerPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmPickerPresenter.swift; sourceTree = "<group>"; };
 		2751201F1AB60D4C007F1219 /* LocationHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationHelper.swift; sourceTree = "<group>"; };
 		275120211AB64932007F1219 /* SoundMonitorHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SoundMonitorHelper.swift; sourceTree = "<group>"; };
+		275120251AB8E4F6007F1219 /* AlarmHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmHelper.swift; sourceTree = "<group>"; };
 		27A71A981AB51551003CABC4 /* SunriseHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SunriseHelper.swift; sourceTree = "<group>"; };
 		27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlurViewPresenter.swift; sourceTree = "<group>"; };
 		27FE93821AB00FE600059E18 /* AlarmEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmEntity.swift; sourceTree = "<group>"; };
@@ -100,11 +102,11 @@
 		253F9DFC1AA95162007A1457 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				273E0DCC1AAD4074005D73E3 /* TimePickerViewController.swift */,
-				254478791AB63411002FA3CB /* SettingsModalViewController.swift */,
 				274DA5661AB4E08900891EBF /* HomeViewController.swift */,
 				273C35A21AAFFEDC00743B33 /* ScheduleTableViewCell.swift */,
 				273C359E1AAFFCDC00743B33 /* ScheduleViewController.swift */,
+				254478791AB63411002FA3CB /* SettingsModalViewController.swift */,
+				273E0DCC1AAD4074005D73E3 /* TimePickerViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -112,12 +114,12 @@
 		254B59CD1AABA36E00A7E3F1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				2544787A1AB63411002FA3CB /* SettingsModalViewController.xib */,
-				273E0DCD1AAD4074005D73E3 /* TimePickerViewController.xib */,
 				274DA5671AB4E08900891EBF /* HomeViewController.xib */,
 				25E7C6991AA8284100431A81 /* LaunchScreen.xib */,
 				273C35A31AAFFEDC00743B33 /* ScheduleTableViewCell.xib */,
 				273C359F1AAFFCDC00743B33 /* ScheduleViewController.xib */,
+				2544787A1AB63411002FA3CB /* SettingsModalViewController.xib */,
+				273E0DCD1AAD4074005D73E3 /* TimePickerViewController.xib */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -187,13 +189,14 @@
 		273E0DD11AAD655B005D73E3 /* Lib */ = {
 			isa = PBXGroup;
 			children = (
-				27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */,
-				275120211AB64932007F1219 /* SoundMonitorHelper.swift */,
-				2751201F1AB60D4C007F1219 /* LocationHelper.swift */,
-				273E0DD21AAD6591005D73E3 /* TimePresenter.swift */,
-				2751201B1AB5AB9A007F1219 /* RawTime.swift */,
+				275120251AB8E4F6007F1219 /* AlarmHelper.swift */,
 				2751201D1AB5C738007F1219 /* AlarmPickerPresenter.swift */,
+				27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */,
+				2751201F1AB60D4C007F1219 /* LocationHelper.swift */,
+				2751201B1AB5AB9A007F1219 /* RawTime.swift */,
+				275120211AB64932007F1219 /* SoundMonitorHelper.swift */,
 				27A71A981AB51551003CABC4 /* SunriseHelper.swift */,
+				273E0DD21AAD6591005D73E3 /* TimePresenter.swift */,
 			);
 			name = Lib;
 			sourceTree = "<group>";
@@ -376,6 +379,7 @@
 				273C35A41AAFFEDC00743B33 /* ScheduleTableViewCell.swift in Sources */,
 				275120221AB64932007F1219 /* SoundMonitorHelper.swift in Sources */,
 				274DA5681AB4E08900891EBF /* HomeViewController.swift in Sources */,
+				275120261AB8E4F6007F1219 /* AlarmHelper.swift in Sources */,
 				275120201AB60D4C007F1219 /* LocationHelper.swift in Sources */,
 				25E7C68E1AA8284100431A81 /* AppDelegate.swift in Sources */,
 				25E7C6911AA8284100431A81 /* alarm.xcdatamodeld in Sources */,

--- a/alarm/AlarmEntity.swift
+++ b/alarm/AlarmEntity.swift
@@ -53,6 +53,28 @@ class AlarmEntity: NSManagedObject {
     }
   }
 
+  // For compatability with NSDateComponent
+  var weekday: Int {
+    get {
+      switch dayOfWeekEnum {
+      case .Sunday:
+        return 1
+      case .Monday:
+        return 2
+      case .Tuesday:
+        return 3
+      case .Wednesday:
+        return 4
+      case .Thursday:
+        return 5
+      case .Friday:
+        return 6
+      case .Saturday:
+        return 7
+      }
+    }
+  }
+
   // Provide a set of enum accessors for the private `alarmType`
   var alarmTypeEnum: AlarmType {
     get {
@@ -104,6 +126,30 @@ class AlarmEntity: NSManagedObject {
     default:
       NSLog("Bad alarm type: \(alarmTypeEnum)")
       return ""
+    }
+  }
+
+  // If this alarm is enabled, when is the next NSDate
+  // for it?
+  // This currently does not handle individual days.
+  func nextAlarmTime() -> NSDate? {
+    if self.enabled {
+      // Match on day of week and time
+      var matchingComponents = NSDateComponents()
+      matchingComponents.weekday = weekday
+      matchingComponents.hour = Int(hour)
+      matchingComponents.minute = Int(minute)
+
+      // Find the next local time that matches what we're looking for
+      // NSCalendar handles timezones for us
+      let calendar = NSCalendar.currentCalendar()
+      return calendar.nextDateAfterDate(
+        NSDate(),
+        matchingComponents: matchingComponents,
+        options: NSCalendarOptions.MatchNextTime
+      )
+    } else {
+      return nil
     }
   }
 

--- a/alarm/AlarmHelper.swift
+++ b/alarm/AlarmHelper.swift
@@ -1,0 +1,53 @@
+//
+//  AlarmHelper.swift
+//  alarm
+//
+//  Created by Michael Lewis on 3/15/15.
+//  Copyright (c) 2015 Kevin Farst. All rights reserved.
+//
+
+import Foundation
+
+// This class is specifically responsible for keeping track of
+// the active alarm. It will ensure that the upcoming alarm is
+// enabled if it needs to be.
+// It is also responsible for managing outstanding alarms, including
+// cancelling them if the active alarm changes.
+
+// Stash a singleton global instance
+private let _alarmHelper = AlarmHelper()
+
+class AlarmHelper {
+
+  var activeAlarm: AlarmEntity?
+  var activeTimer: NSTimer?
+
+  init() {
+  }
+
+  // Create and hold onto a singleton instance of this class
+  class var singleton: AlarmHelper {
+    return _alarmHelper
+  }
+
+
+  /* Public interface */
+
+  // Set the active alarm
+  class func setAlarm(alarm: AlarmEntity) {
+    singleton.setAlarm(alarm)
+  }
+
+
+  /* Private */
+
+  private func setAlarm(alarm: AlarmEntity) {
+    activeAlarm = alarm
+    // If there's an existing timer, kill it
+    if let timer = activeTimer {
+      timer.invalidate()
+    }
+
+    // Create a new timer using the new alarm
+  }
+}

--- a/alarm/AlarmManager.swift
+++ b/alarm/AlarmManager.swift
@@ -1,0 +1,42 @@
+//
+//  AlarmManager.swift
+//  alarm
+//
+//  Created by Michael Lewis on 3/18/15.
+//  Copyright (c) 2015 Kevin Farst. All rights reserved.
+//
+
+import Foundation
+
+// This is responsible for ensuring that the AlarmHelper is always
+// loaded with the most impending alarm
+
+class AlarmManager {
+
+  // Update the alarm helper with the impending alarm
+  // AlarmHelper is idempotent, so it's alright to spam this function.
+  // In practice, this function should be called anytime there is
+  // a meaninful change to the persistence layer of alarms, ie. if
+  // a user changes an alarm.
+  func updateAlarmHelper() {
+    // Get all of the known alarms
+    let alarms = AlarmEntity.MR_findAll() as [AlarmEntity]
+    // Get an array of upcoming alarms, impending first
+    let activeAlarms = alarms.filter({
+      (alarm: AlarmEntity) -> Bool in
+      // Filter out alarms without upcoming times
+      alarm.nextAlarmTime() != nil
+    }).sorted({
+      (a: AlarmEntity, b: AlarmEntity) -> Bool in
+      // Sort them by who has the most impending time
+      a.nextAlarmTime()!.compare(b.nextAlarmTime()!) == NSComparisonResult.OrderedAscending
+    })
+
+    if activeAlarms.count > 0 {
+      AlarmHelper.setAlarm(activeAlarms.first!)
+    } else {
+      AlarmHelper.setAlarm(nil)
+    }
+  }
+
+}

--- a/alarm/AlarmManager.swift
+++ b/alarm/AlarmManager.swift
@@ -18,7 +18,7 @@ class AlarmManager {
   // In practice, this function should be called anytime there is
   // a meaninful change to the persistence layer of alarms, ie. if
   // a user changes an alarm.
-  func updateAlarmHelper() {
+  class func updateAlarmHelper() {
     // Get all of the known alarms
     let alarms = AlarmEntity.MR_findAll() as [AlarmEntity]
     // Get an array of upcoming alarms, impending first

--- a/alarm/AppDelegate.swift
+++ b/alarm/AppDelegate.swift
@@ -42,8 +42,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
       SoundMonitorHelper.startRecording()
     }
-    
+
+    sandboxTest()
+
     return true
+  }
+
+  // This is a dummy func for testing things at startup
+  private func sandboxTest() {
+    var alarmEntity = AlarmEntity.MR_createEntity() as AlarmEntity
+    alarmEntity.dayOfWeekEnum = AlarmEntity.DayOfWeek.Thursday
+    alarmEntity.alarmTypeEnum = .Time
+    alarmEntity.setValue(true, forKey: "enabled")
+    alarmEntity.hour = 7
+    alarmEntity.minute = 0
+
+    AlarmHelper.setAlarm(alarmEntity)
   }
 
   private func setupMagicalRecord() {

--- a/alarm/LocationHelper.swift
+++ b/alarm/LocationHelper.swift
@@ -60,19 +60,19 @@ class LocationHelper: NSObject, CLLocationManagerDelegate {
   /* Location update handler functions */
   func locationManager(manager: CLLocationManager!, didUpdateLocations locations: [AnyObject]!) {
     latestLocation = locations.last as? CLLocation
-    NSLog("location: \(latestLocation?.description)")
+    NSLog("locationManager: didUpdateLocations: \(latestLocation?.description)")
   }
 
   func locationManager(manager: CLLocationManager!, didFailWithError error: NSError!) {
-    NSLog("didFailWithError: \(error.description)")
+    NSLog("locationManager: didFailWithError: \(error.description)")
   }
 
   func locationManager(manager: CLLocationManager!, didFinishDeferredUpdatesWithError error: NSError!) {
-    NSLog("didFinishDeferredUpdatesWithError: \(error.description)")
+    NSLog("locationManager: didFinishDeferredUpdatesWithError: \(error.description)")
   }
 
   func locationManager(manager: CLLocationManager!, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
-    NSLog("Authorization status changed to: \(status.rawValue)")
+    NSLog("locationManager: auth status changed to: \(status.rawValue)")
     setupLocationMonitoring()
   }
 

--- a/alarm/ScheduleViewController.swift
+++ b/alarm/ScheduleViewController.swift
@@ -98,7 +98,6 @@ class ScheduleViewController: UIViewController, UITableViewDataSource, UITableVi
     alarmEntityArray = AlarmEntity.DayOfWeek.allValues.map {
       (dayOfWeekEnum: AlarmEntity.DayOfWeek) -> AlarmEntity in
       var alarmEntity = AlarmEntity.MR_createEntity() as AlarmEntity
-      //alarmEntity.setValue(dayOfWeekEnum, forKey: "dayOfWeekEnum")
       alarmEntity.dayOfWeekEnum = dayOfWeekEnum
       alarmEntity.alarmTypeEnum = .Time
       alarmEntity.setValue(false, forKey: "enabled")

--- a/alarm/SoundMonitorHelper.swift
+++ b/alarm/SoundMonitorHelper.swift
@@ -87,14 +87,11 @@ class SoundMonitorHelper: NSObject, AVAudioRecorderDelegate {
     NSLog("\(error.localizedDescription)")
   }
 
-  func updateAudioMeter(timer:NSTimer) {
+  func updateAudioMeter(timer: NSTimer) {
     if recorder.recording {
       recorder.updateMeters()
       var apc0  = recorder.averagePowerForChannel(0)
       var peak0 = recorder.peakPowerForChannel(0)
-
-      let dFormat = "%02d"
-      NSLog("seconds: \(recorder.currentTime), avg: \(apc0), peak: \(peak0)")
     }
   }
 

--- a/alarm/SunriseHelper.swift
+++ b/alarm/SunriseHelper.swift
@@ -26,7 +26,7 @@ class SunriseHelper {
   let distanceRecalcThreshold = 50000.0 // 50km
 
   init() {
-    calendar = NSCalendar.currentCalendar()
+    calendar = NSCalendar.autoupdatingCurrentCalendar()
   }
 
   // Create and hold onto a singleton instance of this class

--- a/scratch.playground/timeline.xctimeline
+++ b/scratch.playground/timeline.xctimeline
@@ -2,5 +2,8 @@
 <Timeline
    version = "3.0">
    <TimelineItems>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=97&amp;EndingColumnNumber=27&amp;EndingLineNumber=5&amp;StartingColumnNumber=1&amp;StartingLineNumber=5&amp;Timestamp=448401038.611195">
+      </LoggerValueHistoryTimelineItem>
    </TimelineItems>
 </Timeline>


### PR DESCRIPTION
I lost hours of my life to NSDate handling. Fucking headache.

This introduces the `AlarmHelper` singleton. When you assign it an `AlarmEntity` using `setAlarm`, it will handle setting up an NSTimer. When that timer triggers, an event called `"AlarmFired"` will fired, including the `AlarmEntity` instance as the attached object. The idea is that it can be subscribed to by the code that will initiate the wakeup alarm.

There's a layer that lives on top of it called `AlarmManager`. It's pretty simple. You just call it's class function `updateAlarmHelper` and it will figure out which alarm is coming up next and ensure that it's set on `AlarmHelper`. The idempotent nature of `AlarmHelper` means this can be called as often as we like, and should be called any time an alarm is changed in a meaningful way.

@kfarst 
