### PR TITLE
updating schedule for next alarm updates home

### DIFF
--- a/alarm.xcodeproj/project.pbxproj
+++ b/alarm.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		277FFD0A1ABA10890003BE2A /* AlarmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277FFD091ABA10890003BE2A /* AlarmManager.swift */; };
 		27A71A991AB51551003CABC4 /* SunriseHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A71A981AB51551003CABC4 /* SunriseHelper.swift */; };
 		27C827981AB4FCA20021CCD3 /* BlurViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */; };
+		27DD02911ABDF94B00CE0105 /* GlobalConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27DD02901ABDF94B00CE0105 /* GlobalConstants.swift */; };
 		27FE93831AB00FE600059E18 /* AlarmEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FE93821AB00FE600059E18 /* AlarmEntity.swift */; };
 		76C06047841EFB0C443D54BB /* libPods-alarm.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 225B0BBD7F243D40B3608C0A /* libPods-alarm.a */; };
 /* End PBXBuildFile section */
@@ -90,6 +91,7 @@
 		277FFD091ABA10890003BE2A /* AlarmManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmManager.swift; sourceTree = "<group>"; };
 		27A71A981AB51551003CABC4 /* SunriseHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SunriseHelper.swift; sourceTree = "<group>"; };
 		27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlurViewPresenter.swift; sourceTree = "<group>"; };
+		27DD02901ABDF94B00CE0105 /* GlobalConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlobalConstants.swift; sourceTree = "<group>"; };
 		27FE93821AB00FE600059E18 /* AlarmEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlarmEntity.swift; sourceTree = "<group>"; };
 		B44D3343037B9278CEFF019A /* Pods-alarm.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-alarm.release.xcconfig"; path = "Pods/Target Support Files/Pods-alarm/Pods-alarm.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -219,13 +221,14 @@
 				277FFD091ABA10890003BE2A /* AlarmManager.swift */,
 				2508E83E1ABA83B900DFB9D5 /* BackgroundImagePresenter.swift */,
 				27C827971AB4FCA20021CCD3 /* BlurViewPresenter.swift */,
+				27DD02901ABDF94B00CE0105 /* GlobalConstants.swift */,
 				2751201F1AB60D4C007F1219 /* LocationHelper.swift */,
 				2751201B1AB5AB9A007F1219 /* RawTime.swift */,
 				275120211AB64932007F1219 /* SoundMonitorHelper.swift */,
 				27A71A981AB51551003CABC4 /* SunriseHelper.swift */,
+				2508E8401ABB27CB00DFB9D5 /* SwiftColors.swift */,
 				2751201D1AB5C738007F1219 /* TimePickerPresenter.swift */,
 				273E0DD21AAD6591005D73E3 /* TimePresenter.swift */,
-				2508E8401ABB27CB00DFB9D5 /* SwiftColors.swift */,
 			);
 			name = Lib;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 			files = (
 				273C35A01AAFFCDC00743B33 /* ScheduleViewController.swift in Sources */,
 				273E0DCE1AAD4074005D73E3 /* TimePickerViewController.swift in Sources */,
+				27DD02911ABDF94B00CE0105 /* GlobalConstants.swift in Sources */,
 				27A71A991AB51551003CABC4 /* SunriseHelper.swift in Sources */,
 				27C827981AB4FCA20021CCD3 /* BlurViewPresenter.swift in Sources */,
 				2544787B1AB63411002FA3CB /* SettingsModalViewController.swift in Sources */,

--- a/alarm/AlarmEntity.swift
+++ b/alarm/AlarmEntity.swift
@@ -95,6 +95,10 @@ class AlarmEntity: NSManagedObject {
 
   // Given a TimePresenter, apply it to this AlarmEntity
   // This supports both time-based and sunrise/sunset TimePresenters
+  //
+  // NOTE: This is intended to be called exclusively by
+  //  AlarmManager.updateAlarmEntity() so that it can notify
+  //  the app when this change has global schedule impacts.
   func applyTimePresenter(timePresenter: TimePresenter) {
     // Keep whatever type it was
     self.alarmTypeEnum = timePresenter.type

--- a/alarm/AlarmHelper.swift
+++ b/alarm/AlarmHelper.swift
@@ -56,7 +56,10 @@ class AlarmHelper: NSObject {
   // Alarm activation handler
   func alarmFired(timer: NSTimer) {
     NSLog("Triggering alarmFired notification")
-    NSNotificationCenter().postNotificationName("AlarmFired", object: activeAlarm)
+    NSNotificationCenter.defaultCenter().postNotificationName(
+      Notifications.AlarmFired,
+      object: activeAlarm
+    )
   }
 
 

--- a/alarm/GlobalConstants.swift
+++ b/alarm/GlobalConstants.swift
@@ -1,0 +1,16 @@
+//
+//  GlobalConstants.swift
+//  alarm
+//
+//  Created by Michael Lewis on 3/21/15.
+//  Copyright (c) 2015 Kevin Farst. All rights reserved.
+//
+
+import Foundation
+
+struct Notifications {
+  static let AlarmActivated            = "AlarmActivated"
+  static let AlarmCancelled            = "AlarmCancelled"
+  static let AlarmFired                = "AlarmFired"
+  static let NextScheduledAlarmChanged = "NextScheduledAlarmChanged"
+}

--- a/alarm/HomeViewController.swift
+++ b/alarm/HomeViewController.swift
@@ -49,6 +49,14 @@ class HomeViewController: UIViewController, TimePickerDelegate, TimePickerManage
       
     updateDisplay()
     addSettingsModal()
+
+    // If the next scheduled time changes, we want to overwrite our override
+    NSNotificationCenter.defaultCenter().addObserver(
+      self,
+      selector: "updateCurrentTime:",
+      name: Notifications.NextScheduledAlarmChanged,
+      object: nil
+    )
   }
   override func didReceiveMemoryWarning() {
     super.didReceiveMemoryWarning()
@@ -85,6 +93,14 @@ class HomeViewController: UIViewController, TimePickerDelegate, TimePickerManage
     timePickerViewController?.dismissViewControllerAnimated(true, completion: nil)
     timePickerViewController = nil
     blurViewPresenter.hideBlur()
+    updateDisplay()
+  }
+
+  // Allow the currently selected Home screen time to be updated
+  func updateCurrentTime(notification: NSNotification) {
+    let alarmEntity = notification.object as AlarmEntity!
+    NSLog("updateCurrentTime: \(alarmEntity)")
+    currentTime = TimePresenter(alarmEntity: alarmEntity)
     updateDisplay()
   }
 

--- a/alarm/ScheduleViewController.swift
+++ b/alarm/ScheduleViewController.swift
@@ -47,6 +47,8 @@ class ScheduleViewController: UIViewController, UITableViewDataSource, UITableVi
     // Dispose of any resources that can be recreated.
   }
 
+  /* Table functions */
+
   func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return alarmEntityArray.count
   }
@@ -70,6 +72,9 @@ class ScheduleViewController: UIViewController, UITableViewDataSource, UITableVi
   func tableView(tableView: UITableView, accessoryButtonTappedForRowWithIndexPath indexPath: NSIndexPath) {
     NSLog("\(indexPath.row)")
   }
+
+
+  /* Alarm cell time updating */
 
   // Delegate of DayOfWeekAlarmDelegate
   func updateTimeSelected(cell: ScheduleTableViewCell) {
@@ -97,9 +102,10 @@ class ScheduleViewController: UIViewController, UITableViewDataSource, UITableVi
   // Update the displayed time
   private func updateCellBeingChanged(time: TimePresenter) {
     if let cell = cellBeingChanged {
-      cell.alarmEntity.applyTimePresenter(time)
-      AlarmManager.updateAlarmHelper()
+      AlarmManager.updateAlarmEntity(cell.alarmEntity, timePresenter: time)
+      // Update the display for the cell
       cell.updateDisplay()
+      // Clear out our stashed cell reference
       cellBeingChanged = nil
     }
   }


### PR DESCRIPTION
When a change to the schedule changes the next scheduled alarm time, `NextScheduledAlarmChanged` is fired. The Home screen subscribes to this and will clear the override.

@kfarst 
